### PR TITLE
Modify module import in README Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ There are several [demos](https://psychobolt.github.io/react-pie-menu/). Also ch
 ```jsx
 import React from 'react';
 import PieMenu, { Slice } from 'react-pie-menu';
-import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 export default ({ x, y }) => (
   <PieMenu 


### PR DESCRIPTION
## WHY
I tried the README Example. But, the following error occurred.

```
Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined.
You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
```
## Cause
We used Default imports.
```
import FontAwesomeIcon from '@fortawesome/react-fontawesome';
```
We need to use Named imports.
```
import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
```

